### PR TITLE
Fix functional tests for appveyor

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "intern": "~4.1.0",
     "lint-staged": "^6.0.0",
     "mockery": "^2.1.0",
-    "normalize-newline": "^3.0.0",
     "prettier": "1.8.2",
     "rimraf": "^2.6.2",
     "shelljs": "^0.7.8",

--- a/tests/functional/main.ts
+++ b/tests/functional/main.ts
@@ -11,9 +11,11 @@ const appRootDir = path.join(__dirname, '..', '..', '..', 'test-app');
 const platform = os.platform().startsWith('win') ? 'windows' : 'unix';
 
 function normalise(value: string) {
-	value = value.split('# sourceMappingURL')[0];
-	value = value.replace(/\r\n/g, '\n').replace(/\\r\\n/g, '\\n');
-	return value.replace(/main\.[a-z0-9]+\.bundle/, 'main.[HASH].bundle');
+	return value
+		.split('# sourceMappingURL')[0]
+		.replace(/\r\n/g, '\n')
+		.replace(/\\r\\n/g, '\\n')
+		.replace(/main\.[a-z0-9]+\.bundle/, 'main.[HASH].bundle');
 }
 
 function assertOutput(mode: string) {

--- a/tests/functional/main.ts
+++ b/tests/functional/main.ts
@@ -5,11 +5,16 @@ import * as fs from 'fs';
 import * as rimraf from 'rimraf';
 import * as execa from 'execa';
 import * as os from 'os';
-const normalise = require('normalize-newline');
 
 const appRootDir = path.join(__dirname, '..', '..', '..', 'test-app');
 
 const platform = os.platform().startsWith('win') ? 'windows' : 'unix';
+
+function normalise(value: string) {
+	value = value.split('# sourceMappingURL')[0];
+	value = value.replace(/\r\n/g, '\n').replace(/\\r\\n/g, '\\n');
+	return value.replace(/main\.[a-z0-9]+\.bundle/, 'main.[HASH].bundle');
+}
 
 function assertOutput(mode: string) {
 	const fixtureManifest = require(path.join(appRootDir, 'fixtures', platform, mode, 'manifest'));
@@ -21,11 +26,8 @@ function assertOutput(mode: string) {
 		if (id !== 'runtime.js.map') {
 			const fixtureFilePath = path.join(appRootDir, 'fixtures', platform, mode, fixtureManifest[id]);
 			const outputFilePath = path.join(appRootDir, 'output', mode, outputManifest[id]);
-			let fixtureContents = fs.readFileSync(fixtureFilePath, 'utf8');
-			let outputContents = fs.readFileSync(outputFilePath, 'utf8');
-
-			fixtureContents = fixtureContents.split('//# sourceMappingURL')[0];
-			outputContents = outputContents.split('//# sourceMappingURL')[0];
+			const fixtureContents = fs.readFileSync(fixtureFilePath, 'utf8');
+			const outputContents = fs.readFileSync(outputFilePath, 'utf8');
 
 			assert.strictEqual(normalise(outputContents), normalise(fixtureContents), id);
 		}


### PR DESCRIPTION
When executed against Windows, the test fixtures contain a mix of escaped carriage returns and unescaped carriage returns, both of which must be normalized. Further, different newlines between actual and expected values result in different build hashes for the dist configuration; therefore the tests are updated to account for this as well.

I haven't yet been able to figure out why a failing `npm test` does not trigger an appveyor build fail. It does not register a failing test as a condition for a failing build, presumably because the npm task completes regardless of the fact that there are warnings. Do we know yet that Travis fails with a failing test? I haven't been able to confirm that with my account.