### PR TITLE
Fail CI on test failures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ test_script:
   - npm --version
   # run tests
   - node_modules\.bin\grunt.cmd
-  - npm test
+  - npm test-ci
   - node_modules\.bin\grunt.cmd uploadCoverage
 
 # Don't actually build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- npm test
+- npm test-ci
 - grunt uploadCoverage
 notifications:
   slack:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "url": "https://github.com/dojo/cli-build-app.git"
   },
   "scripts": {
-    "test": "npm run build-test-artifact && cd test-app && shx rm -rf node_modules package-lock.json && npm i && grunt test --color",
+    "test": "npm run setup-tests && grunt test --color",
+    "test-ci": "npm run setup-tests && grunt dev && grunt intern:node --test-reporter",
+    "setup-tests": "npm run build-test-artifact && cd test-app && shx rm -rf node_modules package-lock.json && npm i",
     "build-test-artifact": "grunt dist && grunt release-publish-flat --dry-run && shx mv dist/dojo-cli-build-app-* dist/dojo-cli-build-app.tgz",
     "prettier": "prettier --write src/**/*.ts tests/**/*.ts",
     "generate-unix-fixtures": "cd test-app && npm run generate-unix-fixtures && cd ..",


### PR DESCRIPTION
Updates Travis and Appveyor to use the `grunt intern:node` task when running tests, which will cause the task to abort rather than complete with warnings.