### PR TITLE
Fix CI test commands

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ test_script:
   - npm --version
   # run tests
   - node_modules\.bin\grunt.cmd
-  - npm test-ci
+  - npm run test-ci
   - node_modules\.bin\grunt.cmd uploadCoverage
 
 # Don't actually build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- npm test-ci
+- npm run test-ci
 - grunt uploadCoverage
 notifications:
   slack:


### PR DESCRIPTION
This PR just updates the test commands; it does not address the issue I mentioned with the `import()` loader. I updated the loader to use the path itself as the chunk name and regenerated the fixtures, but then spent most of the day trying to figure out why the `dist` output for `runtime.[hash].js` differed between the fixture and the actual output in Appveyor.